### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugfix-report.md
+++ b/.github/ISSUE_TEMPLATE/bugfix-report.md
@@ -1,0 +1,43 @@
+---
+name: Bugfix report
+about: Let us know that you found a way to fix a bug. This should only be used if
+  the solution for the bug is not simply to edit the source code, since you can do
+  a simple pull request for that.
+
+---
+
+## Description of the bug you fixed
+
+A link to an existing bug report issue would be grand.
+
+## Things you'll need
+
+A quick list of the things we'll need in order to implement your proposed fix,
+such as program libraries or new software. Again, links to where we can find
+them would be helpful.
+
+* [Thing 1](example.com)
+
+* Thing 2
+
+* etc
+
+## Intructions
+
+Step-by-step instructions on how to implement the change, with a short
+description of the intended effect of each step.
+
+1. Step one
+
+2. Step two
+
+3. etc
+
+## Attribution Options
+
+We try to provide attribution for everyone who helps with our projects
+by acknowledging them in thanks.txt.
+Please put your name and any website or contact information you feel
+comfortable sharing.  We will be linking your GitHub account.  If you
+would rather remain anonymous, please let us know and we will respect
+that request.


### PR DESCRIPTION
For some reason that I'm sure makes perfect sense, the Bugfix Report template disappeared from the GitHub interface.